### PR TITLE
Add support for node exec options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Add arguments for execution:
 }
 ````
 
+Add options for execution:
+
+````json
+{
+  "miramac.node.options": ["--require", "babel-register"]
+}
+````
+
 Change the node binary for execution
 
 ````json

--- a/lib/activate.js
+++ b/lib/activate.js
@@ -65,6 +65,10 @@ function activate (context) {
       args = args.concat(config.args)
     }
 
+    if (Array.isArray(config.options) && config.options.length > 0) {
+      args = config.options.concat(args)
+    }
+
     let startTime = new Date()
     let nodeBin = (typeof config.nodeBin === 'string') ? config.nodeBin : 'node'
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
            "default": null,
            "description": "Add execution arguments"
         },
+        "miramac.node.options": {
+          "type": ["array", "null"],
+          "default": null,
+          "description": "Add execution options"
+        },
         "miramac.node.legacyMode": {
           "type": "boolean",
            "default": true,

--- a/test/.vscode/settings.json
+++ b/test/.vscode/settings.json
@@ -3,5 +3,6 @@
   "miramac.node.env": {
     "NODE_ENV": "production"
   },
-  "miramac.node.legacyMode": false
+  "miramac.node.legacyMode": false,
+  "miramac.node.options": ["--no-warnings"]
 }

--- a/test/testfile.js
+++ b/test/testfile.js
@@ -9,6 +9,7 @@ function endlessCount (i) {
 }
 
 console.log(process.env.NODE_ENV)
+console.log(process.execArgv)
 console.log(process.argv)
 
 endlessCount(1)


### PR DESCRIPTION
Added new setting "miramac.node.options" to support arguments for node exec itself