### PR TITLE
Fix #40 - change file ext from ".tmp" to ".tmp.js"

### DIFF
--- a/lib/activate.0.2.1.js
+++ b/lib/activate.0.2.1.js
@@ -47,7 +47,7 @@ function activate (context) {
     // get cwd from config and replace placeholder
     let cwd = (typeof config.cwd === 'string') ? config.cwd.replace('${execPath}', dirName) : dirName
     // set tempfile
-    let tmpFile = path.join(dirName, `node_${require('crypto').createHash('sha1').update(Math.random().toString()).digest('hex').substr(0, 13)}.tmp`)
+    let tmpFile = path.join(dirName, `node_${require('crypto').createHash('sha1').update(Math.random().toString()).digest('hex').substr(0, 13)}.tmp.js`)
     // wirte code in temp file and exec the file with node
     fs.writeFileSync(tmpFile, text)
     let startTime = new Date()

--- a/lib/activate.js
+++ b/lib/activate.js
@@ -53,7 +53,7 @@ function activate (context) {
     options.cwd = (typeof config.cwd === 'string') ? config.cwd.replace('${execPath}', dirName) : dirName // eslint-disable-line no-template-curly-in-string
 
     // set tempfile
-    const tmpFile = path.join(dirName, `node_${require('crypto').createHash('sha1').update(Math.random().toString()).digest('hex').substr(0, 13)}.tmp`)
+    const tmpFile = path.join(dirName, `node_${require('crypto').createHash('sha1').update(Math.random().toString()).digest('hex').substr(0, 13)}.tmp.js`)
     // wirte code in temp file and exec the file with node
     fs.writeFileSync(tmpFile, text)
 


### PR DESCRIPTION
This fixes #40 by changing the extension of temporary file to ".tmp.js". 

When `package.json` specifies `"type": "module"`, esm module importer kicks in, checks for file extensions, then the error.