### PR TITLE
feat: default dirName to workspace path if unsaved temp file

### DIFF
--- a/lib/activate.js
+++ b/lib/activate.js
@@ -30,9 +30,13 @@ function activate (context) {
       return // No open text editor
     }
 
-    const dirName = path.dirname(editor.document.fileName)
+    let dirName = path.dirname(editor.document.fileName) || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (dirName === '.') {
+      // default to current workspace if temp file is not saved
+      dirName = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    }
     const extName = path.extname(editor.document.fileName) || '.js'
-    if (!dirName || dirName === '' || dirName === '.') {
+    if (!dirName || dirName === '') {
       vscode.window.showWarningMessage('Unknown working directory! Try to save the file before running.')
       return
     }


### PR DESCRIPTION
Adds support to execute unsaved temp files(e.g. "Untitled 1") by setting the default dirName to the workspace path.